### PR TITLE
Don't throw error when otool end with a non-zero status code

### DIFF
--- a/Sources/Magarikado/BinaryImageFileProvider.swift
+++ b/Sources/Magarikado/BinaryImageFileProvider.swift
@@ -49,8 +49,8 @@ public func buildUUID(for file: URL, architecture: String) throws -> String? {
         file.path,
     ]
 
-    let (status, stdout, stderr) = Utility.runCommand(path: "/usr/bin/xcrun", arguments: arguments)
-    guard status == 0 else { throw MagarikadoError.externalCommandFailed("otool", stderr) }
+    let (status, stdout, _ /*stderr*/) = Utility.runCommand(path: "/usr/bin/xcrun", arguments: arguments)
+    guard status == 0 else { return nil }
 
     guard let match = reUUID.firstMatch(in: stdout, range: NSRange(stdout.startIndex ..< stdout.endIndex, in: stdout)) else { return nil }
     return String(stdout[Range(match.range(at: 1), in: stdout)!])


### PR DESCRIPTION
In getting build UUID from an image, otool end with 1 when the image doesn't have specified architecture. 
Currently it is treated as an error but IMO It's more useful to return `nil` which means "not found".